### PR TITLE
Sync metadata.json license to be same as LICENSE (MIT)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppet-windowsfeature",
   "version": "2.0.1-rc0",
   "author": "puppet",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "summary": "A module that will turn windows features on or off for Windows Server 2008 and above",
   "source": "https://github.com/voxpupuli/puppet-windowsfeature",
   "project_page": "https://github.com/voxpupuli/puppet-windowsfeature",


### PR DESCRIPTION
LICENSE file is MIT, but metadata.json has had Apache-2.0 for quite some time