### PR TITLE
Set minimum version_requirement for Puppet

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,5 +25,11 @@
   ],
   "dependencies": [
 
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
+    }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions