### PR TITLE
(GH-85) Fix typo in provider for source parameter

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -74,7 +74,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     # add restart, subfeatures and a source optionally
     array << '-IncludeAllSubFeature' if @resource[:installsubfeatures] == true
     array << '-Restart' if @resource[:restart] == true
-    array << "-Source #{resource['source']}" unless @resource[:source].to_s.strip.empty?
+    array << "-Source #{resource[:source]}" unless @resource[:source].to_s.strip.empty?
     # raise an error if 2008 tried to install mgmt tools
     if @resource[:installmanagementtools] == true && win2008 == true
       raise Puppet::Error, 'installmanagementtools can only be used with Windows 2012 and above'

--- a/lib/puppet/type/windowsfeature.rb
+++ b/lib/puppet/type/windowsfeature.rb
@@ -34,7 +34,7 @@ Puppet::Type.newtype(:windowsfeature) do
   end
 
   newparam(:source) do
-    # validate is tring or false
+    # validate is String or false
     validate do |value|
       unless value.is_a?(String)
         raise Puppet::Error, 'Parameter source is not a string.'


### PR DESCRIPTION
Previously if a source parameter was specified it was not actually appended to
the PowerShell command.  This commit updates the command generation to use the
correct resource name and fixes a typo in the comments