### PR TITLE
add Import-Module ServerManager for win2012r2 PS commands

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     result = if win2008 == true
                ps('Import-Module ServerManager; Get-WindowsFeature | Select Name,Installed | ConvertTo-XML -As String -Depth 4 -NoTypeInformation')
              else
-               ps('Get-WindowsFeature | ConvertTo-XML -As String -Depth 4 -NoTypeInformation')
+               ps('Import-Module ServerManager; Get-WindowsFeature | ConvertTo-XML -As String -Depth 4 -NoTypeInformation')
              end
     # create the XML document and parse the objects
     xml = Document.new result
@@ -70,7 +70,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     win2008 = Facter.value(:kernelmajversion) == '6.1'
     # set the install line
     array << "Import-Module ServerManager; Add-WindowsFeature #{resource[:name]}" if win2008 == true
-    array << "Install-WindowsFeature #{resource[:name]}" if win2008 == false
+    array << "Import-Module ServerManager; Install-WindowsFeature #{resource[:name]}" if win2008 == false
     # add restart, subfeatures and a source optionally
     array << '-IncludeAllSubFeature' if @resource[:installsubfeatures] == true
     array << '-Restart' if @resource[:restart] == true
@@ -94,7 +94,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     win2008 = Facter.value(:kernelmajversion) == '6.1'
     # set the uninstall line
     array << "Import-Module ServerManager; Remove-WindowsFeature #{resource[:name]}" if win2008 == true
-    array << "Uninstall-WindowsFeature #{resource[:name]}" if win2008 == false
+    array << "Import-Module ServerManager; Uninstall-WindowsFeature #{resource[:name]}" if win2008 == false
     # add the restart flag optionally
     array << '-Restart' if @resource[:restart] == true
     # show the created ps string, get the result, show the result (debug)

--- a/spec/unit/puppet/provider/windowsfeature/default_spec.rb
+++ b/spec/unit/puppet/provider/windowsfeature/default_spec.rb
@@ -88,7 +88,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -IncludeManagementTools' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Install-WindowsFeature feature-name -IncludeManagementTools').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeManagementTools').returns('')
         provider.create
       end
     end

--- a/spec/unit/puppet/provider/windowsfeature/default_spec.rb
+++ b/spec/unit/puppet/provider/windowsfeature/default_spec.rb
@@ -22,7 +22,7 @@ describe provider_class do
   before do
     Facter.stubs(:value).with(:kernel).returns(:windows)
     Facter.stubs(:value).with(:kernelmajversion).returns('6.2')
-    provider.class.stubs(:ps).with('Get-WindowsFeature | ConvertTo-XML -As String -Depth 4 -NoTypeInformation').returns(windows_feature_xml)
+    provider.class.stubs(:ps).with('Import-Module ServerManager; Get-WindowsFeature | ConvertTo-XML -As String -Depth 4 -NoTypeInformation').returns(windows_feature_xml)
   end
 
   it 'supports resource discovery' do
@@ -68,7 +68,7 @@ describe provider_class do
     context 'on Windows 6.2 onward' do
       it 'runs Install-WindowsFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Install-WindowsFeature feature-name').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name').returns('')
         provider.create
       end
     end
@@ -104,7 +104,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -IncludeAllSubFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Install-WindowsFeature feature-name -IncludeAllSubFeature').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeAllSubFeature').returns('')
         provider.create
       end
     end
@@ -120,7 +120,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -Source C:\Windows\sxs' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Install-WindowsFeature feature-name -Source C:\Windows\sxs').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -Source C:\Windows\sxs').returns('')
         provider.create
       end
     end
@@ -136,7 +136,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -Restart' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Install-WindowsFeature feature-name -Restart').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -Restart').returns('')
         provider.create
       end
     end
@@ -153,7 +153,7 @@ describe provider_class do
     context 'on Windows 6.2 onward' do
       it 'runs Uninstall-WindowsFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Uninstall-WindowsFeature feature-name').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Uninstall-WindowsFeature feature-name').returns('')
         provider.destroy
       end
     end
@@ -168,7 +168,7 @@ describe provider_class do
 
       it 'runs Uninstall-WindowsFeature with -Restart' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Uninstall-WindowsFeature feature-name -Restart').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Uninstall-WindowsFeature feature-name -Restart').returns('')
         provider.destroy
       end
     end


### PR DESCRIPTION

I've been testing all day on some win2012r2 machines:
* vagrant: I used this box `MattHodge/Windows2012R2-WMF5-NOCM`
* azure VM
Also tested with Powershell:
* v 5.0
* v 5.1
In all my tests I need to add the `Import-Module ServerManager;` for the correct execution of the commands otherwise, some Powershell commands won't work.