### PR TITLE
Targeted Deprecation Notice of Restart parameter (#120)

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -101,6 +101,4 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     result = ps(array.join(' '))
     Puppet.debug "Powershell destroy response was '#{result}'"
   end
-  
 end
-

--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -66,7 +66,10 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     array << "Import-Module ServerManager; Install-WindowsFeature #{resource[:name]}" if win2008 == false
     # add restart, subfeatures and a source optionally
     array << '-IncludeAllSubFeature' if @resource[:installsubfeatures] == true
-    array << '-Restart' if @resource[:restart] == true
+    if @resource[:restart] == true
+      Puppet.deprecation_warning('The restart parameter has been deprecated in favor of the puppetlabs reboot module ( https://github.com/puppetlabs/puppetlabs-reboot ).  This parameter will be removed in the next release.')
+      array << '-Restart'
+    end
     array << "-Source #{resource[:source]}" unless @resource[:source].to_s.strip.empty?
     # raise an error if 2008 tried to install mgmt tools
     if @resource[:installmanagementtools] == true && win2008 == true
@@ -89,10 +92,15 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     array << "Import-Module ServerManager; Remove-WindowsFeature #{resource[:name]}" if win2008 == true
     array << "Import-Module ServerManager; Uninstall-WindowsFeature #{resource[:name]}" if win2008 == false
     # add the restart flag optionally
-    array << '-Restart' if @resource[:restart] == true
+    if @resource[:restart] == true
+      Puppet.deprecation_warning('The restart parameter has been deprecated in favor of the puppetlabs reboot module ( https://github.com/puppetlabs/puppetlabs-reboot ).  This parameter will be removed in the next release.')
+      array << '-Restart'
+    end
     # show the created ps string, get the result, show the result (debug)
     Puppet.debug "Powershell destroy command is '#{array}'"
     result = ps(array.join(' '))
     Puppet.debug "Powershell destroy response was '#{result}'"
   end
+  
 end
+

--- a/lib/puppet/type/windowsfeature.rb
+++ b/lib/puppet/type/windowsfeature.rb
@@ -17,7 +17,6 @@ Puppet::Type.newtype(:windowsfeature) do
   end
 
   newparam(:restart, boolean: true, parent: Puppet::Parameter::Boolean) do
-    Puppet.deprecation_warning('The restart parameter has been deprecated in favor of the puppetlabs reboot module ( https://github.com/puppetlabs/puppetlabs-reboot ).  This parameter will be removed in the next release.')
   end
 
   newparam(:source) do


### PR DESCRIPTION
#### Pull Request (PR) description

Module should only throw a warning if the restart parameter is being used, not anytime a windowsfeature resource is used

#### This Pull Request (PR) fixes the following issues

Fixes #120 