### PR TITLE
Ignore powershell progress screens

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -19,7 +19,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
   def self.instances
     # an array to store feature hashes
     features = []
-    result = ps('Import-Module ServerManager; Get-WindowsFeature | Select-Object -Property Name, Installed | ConvertTo-XML -As String -Depth 4 -NoTypeInformation')
+    result = ps(%($ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Get-WindowsFeature | Select-Object -Property Name, Installed | ConvertTo-XML -As String -Depth 4 -NoTypeInformation))
     # create the XML document and parse the objects
     xml = Document.new result
     xml.root.each_element do |object|

--- a/spec/unit/puppet/provider/windowsfeature/default_spec.rb
+++ b/spec/unit/puppet/provider/windowsfeature/default_spec.rb
@@ -22,7 +22,7 @@ describe provider_class do
   before do
     Facter.stubs(:value).with(:kernel).returns(:windows)
     Facter.stubs(:value).with(:kernelmajversion).returns('6.2')
-    provider.class.stubs(:ps).with('Import-Module ServerManager; Get-WindowsFeature | Select-Object -Property Name, Installed | ConvertTo-XML -As String -Depth 4 -NoTypeInformation').returns(windows_feature_xml)
+    provider.class.stubs(:ps).with(%($ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Get-WindowsFeature | Select-Object -Property Name, Installed | ConvertTo-XML -As String -Depth 4 -NoTypeInformation)).returns(windows_feature_xml)
   end
 
   it 'supports resource discovery' do


### PR DESCRIPTION
In some remote, non-interactive, connections the triggering of a
progress screen will cause an error like '0x5 occurred while reading
the console output buffer'.

Adding $ProgressPreference='SilentlyContinue' causes 'self.instances' to
successfully complete without error.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
