### PR TITLE
Ignore PowerShell progress bar

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     win2008 = Facter.value(:kernelmajversion) == '6.1'
     # set the install line
     array << "Import-Module ServerManager; Add-WindowsFeature #{resource[:name]}" if win2008 == true
-    array << "Import-Module ServerManager; Install-WindowsFeature #{resource[:name]}" if win2008 == false
+    array << "$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature #{resource[:name]}" if win2008 == false
     # add restart, subfeatures and a source optionally
     array << '-IncludeAllSubFeature' if @resource[:installsubfeatures] == true
     if @resource[:restart] == true
@@ -90,7 +90,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
     win2008 = Facter.value(:kernelmajversion) == '6.1'
     # set the uninstall line
     array << "Import-Module ServerManager; Remove-WindowsFeature #{resource[:name]}" if win2008 == true
-    array << "Import-Module ServerManager; Uninstall-WindowsFeature #{resource[:name]}" if win2008 == false
+    array << "$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Uninstall-WindowsFeature #{resource[:name]}" if win2008 == false
     # add the restart flag optionally
     if @resource[:restart] == true
       Puppet.deprecation_warning('The restart parameter has been deprecated in favor of the puppetlabs reboot module ( https://github.com/puppetlabs/puppetlabs-reboot ).  This parameter will be removed in the next release.')

--- a/spec/unit/puppet/provider/windowsfeature/default_spec.rb
+++ b/spec/unit/puppet/provider/windowsfeature/default_spec.rb
@@ -68,7 +68,7 @@ describe provider_class do
     context 'on Windows 6.2 onward' do
       it 'runs Install-WindowsFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature feature-name").returns('')
         provider.create
       end
     end
@@ -88,7 +88,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -IncludeManagementTools' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeManagementTools').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeManagementTools").returns('')
         provider.create
       end
     end
@@ -104,7 +104,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -IncludeAllSubFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeAllSubFeature').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature feature-name -IncludeAllSubFeature").returns('')
         provider.create
       end
     end
@@ -120,7 +120,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -Source C:\Windows\sxs' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -Source C:\Windows\sxs').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature feature-name -Source C:\\Windows\\sxs").returns('')
         provider.create
       end
     end
@@ -136,7 +136,7 @@ describe provider_class do
 
       it 'runs Install-WindowsFeature with -Restart' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Install-WindowsFeature feature-name -Restart').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature feature-name -Restart").returns('')
         provider.create
       end
     end
@@ -153,7 +153,7 @@ describe provider_class do
     context 'on Windows 6.2 onward' do
       it 'runs Uninstall-WindowsFeature' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Uninstall-WindowsFeature feature-name').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Uninstall-WindowsFeature feature-name").returns('')
         provider.destroy
       end
     end
@@ -168,7 +168,7 @@ describe provider_class do
 
       it 'runs Uninstall-WindowsFeature with -Restart' do
         Facter.expects(:value).with(:kernelmajversion).returns('6.2')
-        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with('Import-Module ServerManager; Uninstall-WindowsFeature feature-name -Restart').returns('')
+        Puppet::Type::Windowsfeature::ProviderDefault.expects('ps').with("$ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Uninstall-WindowsFeature feature-name -Restart").returns('')
         provider.destroy
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description

(#138) '0x5 occurred while reading the console output buffer' errors occur on
non-interactive connections to Windows 2019.

Adding $ProgressPreference='SilentlyContinue' prior to Install and
Uninstall actions allows them to complete with no error.

#### This Pull Request (PR) fixes the following issues

Fixes #138

