### PR TITLE
add command line parameters to powershell.exe

### DIFF
--- a/lib/puppet/provider/windowsfeature/default.rb
+++ b/lib/puppet/provider/windowsfeature/default.rb
@@ -93,7 +93,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
       '-NoLogo',
       '-ExecutionPolicy', 'Bypass',
       '-Command',
-      "#{array.join(' ')}"
+      array.join(' ')
     )
     Puppet.debug "Powershell create response was '#{result}'"
   end
@@ -119,7 +119,7 @@ Puppet::Type.type(:windowsfeature).provide(:default) do
       '-NoLogo',
       '-ExecutionPolicy', 'Bypass',
       '-Command',
-      "#{array.join(' ')}"
+      array.join(' ')
     )
     Puppet.debug "Powershell destroy response was '#{result}'"
   end

--- a/spec/unit/puppet/provider/windowsfeature/default_spec.rb
+++ b/spec/unit/puppet/provider/windowsfeature/default_spec.rb
@@ -216,6 +216,7 @@ describe provider_class do
         provider.destroy
       end
     end
+
     context 'with restart' do
       let(:resource) do
         Puppet::Type.type(:windowsfeature).new(


### PR DESCRIPTION
#### Pull Request (PR) description
Adds command line parameters to powershell.exe to not load powershell profile, hides the copyright banner at startup, create sessions that shouldn't require user input and sets executionpolicy to bypass.

#### Before
`Executing: 'C:\Windows\system32\WindowsPowershell\v1.0\powershell.exe $ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature telnet-client'`

#### After
`Executing: 'C:\Windows\system32\WindowsPowershell\v1.0\powershell.exe -NoProfile -NonInteractive -NoLogo -ExecutionPolicy Bypass -Command $ProgressPreference='SilentlyContinue'; Import-Module ServerManager; Install-WindowsFeature telnet-client'`

#### This Pull Request (PR) fixes the following issues
Fixes #175
Fixes #168